### PR TITLE
Fix: Submodule path separator issue in .gitmodules for Windows compatibility and GLSL input keyword shader error.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule ".\\dependencies\\submodules\\delta-studio"]
-	path = .\\dependencies\\submodules\\delta-studio
+[submodule "dependencies/submodules/delta-studio"]
+	path = dependencies/submodules/delta-studio
 	url = https://github.com/ange-yaghi/delta-studio

--- a/assets/shaders/glsl/bloom/bloom.frag
+++ b/assets/shaders/glsl/bloom/bloom.frag
@@ -46,9 +46,9 @@ vec3 hableTonemapPartial(vec3 s) {
 	return ((s * (A * s + C * B) + D * E) / (s * (A * s + B) + D * F)) - E/F;
 }
 
-vec3 hableTonemap(vec3 input) {
+vec3 hableTonemap(vec3 colorInput) {
 	const float exposureBias = 2.0f;
-	const vec3 mapped = hableTonemapPartial(exposureBias * input);
+	const vec3 mapped = hableTonemapPartial(exposureBias * colorInput);
 
 	const vec3 W = vec3(11.3f);
 	const vec3 whiteScale = vec3(1.0f) / hableTonemapPartial(W);
@@ -74,14 +74,14 @@ vec3 toBlackAndWhite(vec3 c) {
 }
 
 void main(void) {
-    const vec3 input = texture(Input, ex_Tex).rgb;
+    const vec3 baseColor  = texture(Input, ex_Tex).rgb;
     const vec3 bloom = texture(InputBloom, ex_Tex).rgb;
 
-	const vec3 final = input + bloom * BloomAmount;
+	const vec3 final = baseColor  + bloom * BloomAmount;
 	const vec3 tonemapped = hableTonemap(final);
 	const vec3 srgb = linearToSrgb(tonemapped);
 	const vec3 dithered = mix(srgb, orderedDither(srgb), DitherAmount);
 	const vec3 filtered = mix(dithered, toBlackAndWhite(dithered), DebugBlackAndWhite);
-    
-    out_Color = vec4(filtered, 1.0);	
+
+    out_Color = vec4(filtered, 1.0);
 }


### PR DESCRIPTION
This PR fixes an issue where the `delta-studio` submodule fails to initialize or update correctly on Windows systems and GLSL Fragment Shader Compilation.

**Problem 1 :**
The `.gitmodules` file uses backslashes (`\`) in the `path` definition (`.\\dependencies\\submodules\\delta-studio`). Git expects forward slashes (`/`) for paths in `.gitmodules` regardless of the operating system to ensure cross-platform compatibility.

**Solution 1:**
This change updates the `path` to use forward slashes (`dependencies/submodules/delta-studio`).

**Verification 1:**
I've confirmed that after this change, `git submodule sync` and `git submodule update --init --recursive` correctly download and initialize the `delta-studio` submodule on a Windows environment. This aligns the repository with Git's cross-platform best practices for submodule paths.


**Problem 2 :**
The bloom fragment shader (`assets/shaders/glsl/bloom/bloom.frag`) for opengl failed to compile due to the use of `input` as a variable name. `input` is a reserved keyword in GLSL, leading to a compilation error. This error prevented the graphics pipeline from initializing, causing the application to crash or not render correctly.

**Solution 2:**
Renamed the conflicting `input` variable to a non-reserved, more descriptive name (e.g., `baseColor`, `colorInput`) within the fragment shader. This resolves the compilation error, allowing the shader to build and the graphics to render as intended.

**Verification 2:**
Built the project and ran it to confirm it renderers properly.

**Overall Verification:**
Confirmed by performing a full project build and successfully running the application.